### PR TITLE
Fixed border related problem

### DIFF
--- a/geraldo/generators/base.py
+++ b/geraldo/generators/base.py
@@ -248,6 +248,10 @@ class ReportGenerator(GeraldoObject):
             self._rendered_pages[-1].add_element(widget)
 
             # Borders
+            # FIXME: This fix a border related bug when using an array of values (table-like)
+            if widget.borders and 'all' in widget.borders and isinstance(widget.borders['all'], Rect):
+                widget.borders['all'] = widget.borders['all'].clone()
+
             self.render_border(widget.borders or {}, widget_rect)
 
         # Graphic element


### PR DESCRIPTION
This pull request fixes a border related bug when using an array of values (table-like)

PT_BR:
Vou explicar em português. Estou gerando um arquivo em PDF, passando os dados a serem preenchidos no arquivo através de um objeto (atributo _current_object). Nesse objeto tem um atributo que é uma lista de dados. Os campos dessa lista possuem bordas, porém na renderização, apenas a última linha de dados é renderizada com bordas.

Não tenho muito conhecimento sobre o geraldo, pois essa geração de PDF foi implementada por outra pessoa (Aristides Caldeira) no projeto PySPED para a geração de DANFE. Apenas fiz algumas alterações nessa implementação do Ari para fazer funcionar na versão atual do geraldo. Minhas alterações estão no seguinte projeto: https://github.com/proge/PySPED-NFe

Acho que quando tu olhar a alteração que fiz, pode entender o que pode estar acontecendo e pensar numa solução boa.
